### PR TITLE
Pin colors version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "^2.1.4",
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "commander": "^2.9.0",
     "lodash": "^4.17.2",
     "readdir": "^0.0.13",


### PR DESCRIPTION
colors>1.4.0 has been compromised - https://www.theverge.com/2022/1/9/22874949/developer-corrupts-open-source-libraries-projects-affected

1.4.0 was the last safe version.